### PR TITLE
Fix todos

### DIFF
--- a/fero-server/src/database/mod.rs
+++ b/fero-server/src/database/mod.rs
@@ -78,22 +78,14 @@ impl Configuration {
 
         let mut weight = 0;
         for id in ids {
-            // TODO use JOIN
-            if let Some(user) = schema::users::dsl::users
+            weight += schema::user_secret_weights::table
+                .select(schema::user_secret_weights::columns::weight)
+                .inner_join(schema::users::table)
+                .filter(schema::user_secret_weights::columns::secret_id.eq(secret.id))
                 .filter(schema::users::columns::key_id.eq(id))
-                .load::<UserKey>(&conn)?
-                .pop() {
-                weight += schema::user_secret_weights::dsl::user_secret_weights
-                    .filter(schema::user_secret_weights::columns::secret_id.eq(
-                        secret.id,
-                    ))
-                    .filter(schema::user_secret_weights::columns::user_id.eq(user.id))
-                    .load::<UserKeyWeight>(&conn)?
-                    .pop()
-                    .map(|w| w.weight)
-                    .unwrap_or(0)
-            }
-
+                .load(&conn)?
+                .pop()
+                .unwrap_or(0);
         }
 
         if weight >= secret.threshold {


### PR DESCRIPTION
* Don't use `unwrap()` when verifying signatures. The TODO there doesn't seem possible, as gnupg still does not seem to be filling in the `key` field of signatures.
* Use a join when summing signature weights.