### PR TITLE
*/Dockerfile: use rust 1.27

### DIFF
--- a/fero-bastion/Dockerfile
+++ b/fero-bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:stretch as build
+FROM rust:1.27-stretch as build
 
 ADD https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
     /tmp/protoc.zip

--- a/fero-server/Dockerfile
+++ b/fero-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:stretch as build
+FROM rust:1.27-stretch as build
 
 ADD https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip \
     /tmp/protoc.zip


### PR DESCRIPTION
Use rust 1.27 since a compiler change means newer versions do not work.